### PR TITLE
fix bugs,check description in change log

### DIFF
--- a/change log.txt
+++ b/change log.txt
@@ -1,0 +1,6 @@
+2018.3.16 修复了几个使用中发现的的bug
+1. Line71  watch里添加对offset的监听，因其在使用时有时会取到undefined，导致currentSlide计算不出来
+2. Line78  computed里添加对touchable的判断，因其在使用时有时会取到undefined
+3. Line120  在currentSlide里添加判断，当其被四舍五入后等于slideNum时（最大值应是slideNum-1），置为0，因（slideNum-0.5,slideNum）与取（0，0.5）合并为上下滑动不超过一半距离的情况
+4. Line240  判断条件不正确，NaN与自身并不相等
+5. Line261  offset=0 时没有动画效果，是个奇怪的问题，故等于0时给个1（与目标位置偏离了一点点）

--- a/src/carousel.vue
+++ b/src/carousel.vue
@@ -67,9 +67,19 @@ export default {
               );
         });
       }
+    },
+    offset: function (newv, oldv) {
+      if (!newv){
+        this.offset = oldv;
+      }
     }
   },
   computed: {
+    touchable: function () {
+      return this.options.touchable === undefined
+        ? true
+        : this.options.touchable
+    },
     containerHeight: {
       get: function() {
         return this.options.initTZ.height;
@@ -107,19 +117,21 @@ export default {
       return this.options.num;
     },
     currentSlide: function() {
+      let slideTemp;
       if (this.isVertical) {
-        return Math.round(
+        slideTemp = Math.round(
           (this.offset / this.theta) % this.slideNum < 0
             ? this.slideNum + (this.offset / this.theta) % this.slideNum
             : (this.offset / this.theta) % this.slideNum
         );
       } else {
-        return (this.offset / this.theta) % this.slideNum <= 0
+        slideTemp = (this.offset / this.theta) % this.slideNum <= 0
           ? Math.round(Math.abs(this.offset / this.theta)) % this.slideNum
           : Math.round(
               this.slideNum - (this.offset / this.theta) % this.slideNum
             ) % this.slideNum;
       }
+      return (slideTemp !== this.slideNum) ? slideTemp : 0;
     },
     /**
      * @description the carousel direction , default is horizontal
@@ -221,9 +233,14 @@ export default {
     },
     adjustAngle: function() {
       console.log(this.offset);
-      this.offset === NaN
-        ? (this.offset = this.currentSlide * this.theta)
-        : void 0;
+      // 此判断条件写法不正确
+//      this.offset === NaN
+//        ? (this.offset = this.currentSlide * this.theta)
+//        : void 0;
+      // 正确的写法
+      if (!this.offset){
+        this.offset = this.currentSlide * this.theta;
+      };
       let ceil = Math.ceil(this.offset / this.theta);
       let bl = Math.abs(this.theta * ceil - this.offset) < this.theta / 2;
       let s =
@@ -241,6 +258,8 @@ export default {
       this.istouching = false;
       this.options.istouching = false;
       this.methods === undefined ? void 0 : this.methods();
+      // offset=0 时没有动画效果，是个奇怪的问题，故等于0时给个1
+      (!this.offset) ? this.offset=1 : void 0;
     },
     moveRight: function(step) {
       step === undefined ? (step = 0) : void 0;


### PR DESCRIPTION
1.   watch里添加对offset的监听，因其在使用时有时会取到undefined，导致currentSlide计算不出来
2.  computed里添加对touchable的判断，因其在使用时有时会取到undefined
3.  在currentSlide里添加判断，当其被四舍五入后等于slideNum时（最大值应是slideNum-1），置为0，因（slideNum-0.5,slideNum）与取（0，0.5）合并为上下滑动不超过一半距离的情况
4.   判断条件不正确，NaN与自身并不相等
5.   offset=0 时没有动画效果，是个奇怪的问题，故等于0时给个1（与目标位置偏离了一点点）